### PR TITLE
Fix Instant example

### DIFF
--- a/Examples/PSPDFCatalog/PSPDFCatalog/Catalog/Instant/InstantDocumentViewController.cs
+++ b/Examples/PSPDFCatalog/PSPDFCatalog/Catalog/Instant/InstantDocumentViewController.cs
@@ -62,23 +62,13 @@ namespace PSPDFCatalog {
 			}
 		}
 
-		protected override void Dispose (bool disposing)
+		public override void ViewDidDisappear(bool animated)
 		{
-			if (disposing) {
-				// Since this demo is ephemeral, clean up immediately.
-				// Note that this also cancels syncing that is in-progress.
-				documentDescriptor.RemoveLocalStorage (out var error);
-			}
-			base.Dispose (disposing);
+			base.ViewDidDisappear(animated);
+
+			// Since this demo is ephemeral, clean up immediately.
+			// Note that this also cancels syncing that is in-progress.
+			documentDescriptor.RemoveLocalStorage(out var error);
 		}
-
-        public override void ViewDidDisappear(bool animated)
-        {
-            base.ViewDidDisappear(animated);
-
-            // Since this demo is ephemeral, clean up immediately.
-            // Note that this also cancels syncing that is in-progress.
-            documentDescriptor.RemoveLocalStorage(out var error);
-        }
 	}
 }

--- a/Examples/PSPDFCatalog/PSPDFCatalog/Catalog/Instant/InstantDocumentViewController.cs
+++ b/Examples/PSPDFCatalog/PSPDFCatalog/Catalog/Instant/InstantDocumentViewController.cs
@@ -71,5 +71,14 @@ namespace PSPDFCatalog {
 			}
 			base.Dispose (disposing);
 		}
+
+        public override void ViewDidDisappear(bool animated)
+        {
+            base.ViewDidDisappear(animated);
+
+            // Since this demo is ephemeral, clean up immediately.
+            // Note that this also cancels syncing that is in-progress.
+            documentDescriptor.RemoveLocalStorage(out var error);
+        }
 	}
 }


### PR DESCRIPTION
Reported in Z#10123

---

# Details

## How to Reproduce:

1. Launch the Instant demo at https://pspdfkit.com/instant/demo/
2. Launch the Xamarin-iOS sample PSPDFCatalog
3. Go to Instant and enter the code
4. At this point, real-time syncing works correctly in both directions
5. On the iOS app press the back navigation
6. Delete and re-enter the last character of the code to relaunch the same document
7. Make an edit on iOS.  At this point, the web does not update.
8. Make an edit on the web.  This syncs the changes from iOS.  But from this point forward real-time syncing no longer works at all.

The cause of this issue is that `Dispose()` is not getting called when the Instant view controller is dismissed, meaning that we weren’t cleaning after us.

# Acceptance Criteria

- [x] Fix the sync issue in the Catalog Instant example
