### PR TITLE
Remove local storage before downloading in case the app crashed and we didn't remove it `ViewDidDisappear`.

### DIFF
--- a/Examples/PSPDFCatalog/PSPDFCatalog/Catalog/Instant/InstantDocumentViewController.cs
+++ b/Examples/PSPDFCatalog/PSPDFCatalog/Catalog/Instant/InstantDocumentViewController.cs
@@ -29,6 +29,9 @@ namespace PSPDFCatalog {
 			documentCode = docInfo.EncodedDocumentId;
 			webUrl = NSUrl.FromString (docInfo.Url);
 
+			// Remove local storage before downloading in case the app crashed and we didn't remove it `ViewDidDisappear`.
+			documentDescriptor.RemoveLocalStorage(out var localStorageError);
+
 			// Tell Instant to download the document from web-preview’s PSPDFKit Server instance.
 			documentDescriptor.Download (docInfo.Jwt, out var _);
 

--- a/Examples/PSPDFCatalog/PSPDFCatalog/Catalog/Instant/InstantDocumentViewController.cs
+++ b/Examples/PSPDFCatalog/PSPDFCatalog/Catalog/Instant/InstantDocumentViewController.cs
@@ -23,14 +23,15 @@ namespace PSPDFCatalog {
 
 			//strong references they would deallocate and syncing would stop.
 			client = new PSPDFInstantClient (NSUrl.FromString (docInfo.ServerUrl), out var err);
+
+			// Remove local storage before downloading in case the app crashed and we didn't remove it `ViewDidDisappear`.
+			client.RemoveLocalStorage(out var localStorageError);
+
 			documentDescriptor = client.GetDocumentDescriptor (docInfo.Jwt, out var error);
 
 			// Store document code and URL (which also contains the code) for sharing later.
 			documentCode = docInfo.EncodedDocumentId;
 			webUrl = NSUrl.FromString (docInfo.Url);
-
-			// Remove local storage before downloading in case the app crashed and we didn't remove it `ViewDidDisappear`.
-			documentDescriptor.RemoveLocalStorage(out var localStorageError);
 
 			// Tell Instant to download the document from web-preview’s PSPDFKit Server instance.
 			documentDescriptor.Download (docInfo.Jwt, out var _);


### PR DESCRIPTION
This is a followup for #11 