### PR TITLE
Add example for getting touch coordinates

### DIFF
--- a/Examples/PSPDFCatalog/PSPDFCatalog/Catalog/Interactions/InteractionsViewController.cs
+++ b/Examples/PSPDFCatalog/PSPDFCatalog/Catalog/Interactions/InteractionsViewController.cs
@@ -1,0 +1,38 @@
+using System;
+using Foundation;
+
+using PSPDFKit.Model;
+using PSPDFKit.UI;
+using UIKit;
+
+namespace PSPDFCatalog {
+	public class InteractionsController : PSPDFViewController {
+		public InteractionsController (PSPDFDocument document) : base (document)
+		{
+			//Set up your gesture recognizer.
+			var gestureRecognizer = new UITapGestureRecognizer ();
+			var selector = new ObjCRuntime.Selector ("TapGestureRecognizerDidChangeState:");
+			gestureRecognizer.AddTarget (this, selector);
+
+			// Make it work simultaneously with all built-in interaction components.
+			Interactions.AllInteractions.AllowSimultaneousRecognition (gestureRecognizer);
+
+			// Add your gesture recognizer to the document view controller's view.
+			DocumentViewController.View.AddGestureRecognizer (gestureRecognizer);
+		}
+
+		// Perform your action.
+		[Action ("TapGestureRecognizerDidChangeState:")]
+		private void TapGestureRecognizerDidChangeState (UITapGestureRecognizer gestureRecognizer)
+		{
+			if (gestureRecognizer.State == UIGestureRecognizerState.Ended) {
+				var pageView = DocumentViewController.GetVisiblePageView (gestureRecognizer.LocationInView (DocumentViewController.View));
+				if (pageView != null) {
+					Console.WriteLine ($"Tapped at point: {gestureRecognizer.LocationInView (DocumentViewController.View)} in page view: {pageView}");
+				}
+			}
+		}
+
+	}
+
+}

--- a/Examples/PSPDFCatalog/PSPDFCatalog/Catalog/Interactions/InteractionsViewController.cs
+++ b/Examples/PSPDFCatalog/PSPDFCatalog/Catalog/Interactions/InteractionsViewController.cs
@@ -28,7 +28,13 @@ namespace PSPDFCatalog {
 			if (gestureRecognizer.State == UIGestureRecognizerState.Ended) {
 				var pageView = DocumentViewController.GetVisiblePageView (gestureRecognizer.LocationInView (DocumentViewController.View));
 				if (pageView != null) {
-					Console.WriteLine ($"Tapped at point: {gestureRecognizer.LocationInView (DocumentViewController.View)} in page view: {pageView}");
+					// Get the tap point in the view coordinate space.
+					var tapPoint = gestureRecognizer.LocationInView (pageView);
+
+					// Convert the tap point to PDF coordinate space.
+					// For more details, see https://pspdfkit.com/guides/ios/faq/coordinate-spaces/
+					var pdfPoint = pageView.ConvertPointToCoordinateSpace(tapPoint, pageView.PdfCoordinateSpace);
+					Console.WriteLine ($"Tapped at point: {pdfPoint} in page view: {pageView}");
 				}
 			}
 		}

--- a/Examples/PSPDFCatalog/PSPDFCatalog/DVCMenu.cs
+++ b/Examples/PSPDFCatalog/PSPDFCatalog/DVCMenu.cs
@@ -132,6 +132,13 @@ namespace PSPDFCatalog {
                         });
                     }),
                 },
+                new Section ("Interactions"){
+                    new StringElement ("Get Touch Coordinates", () => {
+                        var document =new PSPDFDocument (NSUrl.FromFilename (PSPDFKitFile));
+                        var pdfViewer = new InteractionsController (document);
+                        NavigationController.PushViewController (pdfViewer, true);
+                    }),
+                },
                 new Section("Search")
                 {
                     new StringElement ("FTS with Document Picker", () =>

--- a/Examples/PSPDFCatalog/PSPDFCatalog/PSPDFCatalog.csproj
+++ b/Examples/PSPDFCatalog/PSPDFCatalog/PSPDFCatalog.csproj
@@ -150,6 +150,7 @@
     <Compile Include="Catalog\Forms\CreateFormFieldFromCode.cs" />
     <Compile Include="Catalog\Annotations\JavaScriptActionsViewController.cs" />
     <Compile Include="Catalog\AnnotationHelper.cs" />
+    <Compile Include="Catalog\Interactions\InteractionsViewController.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>
@@ -165,6 +166,7 @@
     <Folder Include="Catalog\Analytics\" />
     <Folder Include="Catalog\Forms\" />
     <Folder Include="Catalog\Search\" />
+    <Folder Include="Catalog\Interactions\" />
   </ItemGroup>
   <ItemGroup>
     <ImageAsset Include="Resources\Images.xcassets\AppIcons.appiconset\Contents.json" />


### PR DESCRIPTION
This example prints the PDF coordinates of finger touches into the console. More or less a guide translation for https://pspdfkit.com/guides/ios/migration-guides/pspdfkit-9-5-migration-guide/#observing-tap-and-long-press-gestures